### PR TITLE
Refactor to transform

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,45 +1,45 @@
 const Parser = require('jsonparse');
-const { Writable } = require('stream');
+const { Transform } = require('stream');
 
-class JSONDocStream extends Writable {
-  constructor(options) {
-    super(options);
-    this._reset();
-  }
-
-  _reset() {
-    if (this.parser) {
-      delete this.parser.onValue;
-      delete this.parser.onError;
-    }
-    this.parser = new Parser();
-    this.error = undefined;
-
-    this.parser.onError = error => {
-      this.error = error;
-    };
-
-    this.parser.onValue = value => {
-      if (this.parser.stack.length === 0) {
-        this.emit('parsed', value);
-      }
-    };
-  }
-
-  _write(chunk, encoding, callback) {
-    // Send the chunk one byte at a time and
-    // reset if we encounter an error
-    const length = chunk.length;
-    for (let i = 0; i < length; i++) {
-      const character = Buffer.alloc(1, chunk[i]);
-      this.parser.write(character);
-      if (this.error) {
-        this.emit('error', this.error);
+class JSONDocStream extends Transform {
+    // Based on json-doc-stream
+    constructor(options) {
+        super({objectMode: true, ...options});
         this._reset();
-      }
     }
-    callback();
-  }
-}
+
+    _transform(chunk, encoding, callback) {
+        const length = chunk.length;
+        for (let i = 0; i < length; i++) {
+            const character = Buffer.alloc(1, chunk[i]);
+            this.parser.write(character);
+            if (this.error) {
+                this.emit('error', this.error);
+                this._reset();
+            }
+        }
+        return callback();
+    }
+
+    _reset() {
+        if (this.parser) {
+            delete this.parser.onValue;
+            delete this.parser.onError;
+        }
+        this.parser = new Parser();
+        this.error = undefined;
+
+        this.parser.onError = error => {
+            this.error = error;
+        };
+        const ctx = this;
+
+        this.parser.onValue = value => {
+            if (this.parser.stack.length === 0) {
+                return ctx.push(value);
+            }
+        };
+    }
+};
 
 module.exports = JSONDocStream;


### PR DESCRIPTION
In my opinion, what you want to receive is a stream transformation. By using Transform, you have backpressing, which significantly improves memory management, as it provides a return channel between the stream source and its consumer. The source of the stream does not read data faster than the consumer can accept it.